### PR TITLE
deprecate ik_node executable, and have nao_ik executable as replaceme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 This ROS2 package can be used to solve inverse kinematics of a NAO's legs joints.
 
+## Nodes
+
+One node is provided, which performs the invverse kinematics via publishers and subscriptions:
+
+```sh
+# If using Rolling, or J-turtle onwards
+ros2 run nao_ik nao_ik
+
+# If using I-turtle or earlier
+ros2 run nao_ik ik_node
+```
+
 ## Subscription
 `motion/sole_poses` (*biped_interfaces/msg/SolePoses.msg*)
 

--- a/nao_ik/CMakeLists.txt
+++ b/nao_ik/CMakeLists.txt
@@ -7,17 +7,19 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(nao_lola_command_msgs REQUIRED)
 find_package(biped_interfaces REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-include_directories(
+include_directories(  # (Deprecated as of J-turtle)
   include
   ${EIGEN3_INCLUDE_DIR}
 )
 
-# Build ik
+# Build ik_node (Deprecated as of J-turtle)
 add_executable(ik_node
   src/ik_node.cpp
   src/ik.cpp
@@ -30,15 +32,53 @@ ament_target_dependencies(ik_node
   biped_interfaces
   Eigen3)
 
+# Build nao_ik_node library, and nao_ik executable
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  rclcpp
+  rclcpp_components
+  nao_lola_command_msgs
+  biped_interfaces
+  Eigen3)
+
+add_library(nao_ik_node SHARED
+  src/nao_ik.cpp
+  src/bhuman/ik_bhuman.cpp
+  src/bhuman/RotationMatrix.cpp)
+
+target_include_directories(nao_ik_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${EIGEN3_INCLUDE_DIR})
+
+rclcpp_components_register_node(nao_ik_node
+  PLUGIN "nao_ik::NaoIK"
+  EXECUTABLE nao_ik)
+
+ament_target_dependencies(nao_ik_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+ament_export_targets(export_nao_ik HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+
 # Install
-install(TARGETS
+install(TARGETS  # (Deprecated as of J-turtle)
   ik_node
   DESTINATION lib/${PROJECT_NAME})
+install(
+  DIRECTORY include/
+  DESTINATION include)
+install(
+  TARGETS nao_ik_node
+  EXPORT export_nao_ik
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include)
 
-
+# Test
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+# Package
 ament_package()

--- a/nao_ik/include/nao_ik/nao_ik.hpp
+++ b/nao_ik/include/nao_ik/nao_ik.hpp
@@ -1,0 +1,40 @@
+// Copyright 2021 Kenji Brameld
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NAO_IK__NAO_IK_HPP_
+#define NAO_IK__NAO_IK_HPP_
+
+#include "rclcpp/rclcpp.hpp"
+#include "nao_lola_command_msgs/msg/joint_positions.hpp"
+#include "biped_interfaces/msg/sole_poses.hpp"
+
+namespace nao_ik
+{
+
+class NaoIK : public rclcpp::Node
+{
+public:
+  explicit NaoIK(const rclcpp::NodeOptions & options = rclcpp::NodeOptions{});
+
+private:
+  nao_lola_command_msgs::msg::JointPositions calculate_joints(
+    biped_interfaces::msg::SolePoses & sole_poses);
+
+  rclcpp::Subscription<biped_interfaces::msg::SolePoses>::SharedPtr sub_sole_poses;
+  rclcpp::Publisher<nao_lola_command_msgs::msg::JointPositions>::SharedPtr pub_joints;
+};
+
+}  // namespace nao_ik
+
+#endif  // NAO_IK__NAO_IK_HPP_

--- a/nao_ik/package.xml
+++ b/nao_ik/package.xml
@@ -12,7 +12,9 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>nao_lola_command_msgs</depend>
   <depend>biped_interfaces</depend>
   <depend>eigen</depend>

--- a/nao_ik/src/ik.cpp
+++ b/nao_ik/src/ik.cpp
@@ -19,7 +19,8 @@
 IK::IK()
 : Node("IK")
 {
-  RCLCPP_WARN(get_logger(),
+  RCLCPP_WARN(
+    get_logger(),
     "The use of 'ik_node' executable is deprecated as of J-turtle. "
     "Please use the 'nao_ik' executable instead. Eg. 'ros2 run nao_ik nao_ik'");
 

--- a/nao_ik/src/nao_ik.cpp
+++ b/nao_ik/src/nao_ik.cpp
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "nao_ik/ik.hpp"
+#include "nao_ik/nao_ik.hpp"
 #include "nao_lola_command_msgs/msg/joint_indexes.hpp"
 #include "nao_ik/bhuman/ik_bhuman.hpp"
 
-IK::IK()
-: Node("IK")
+namespace nao_ik
 {
-  RCLCPP_WARN(get_logger(),
-    "The use of 'ik_node' executable is deprecated as of J-turtle. "
-    "Please use the 'nao_ik' executable instead. Eg. 'ros2 run nao_ik nao_ik'");
 
+NaoIK::NaoIK(const rclcpp::NodeOptions & options)
+: rclcpp::Node{"NaoIK", options}
+{
   sub_sole_poses =
     create_subscription<biped_interfaces::msg::SolePoses>(
     "motion/sole_poses", 1,
@@ -43,3 +42,8 @@ IK::IK()
     "effectors/joint_positions",
     10);
 }
+
+}  // namespace nao_ik
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(nao_ik::NaoIK)


### PR DESCRIPTION
…nt. Use rclcpp components so nao_ik can be used as a component or library too.

Resolves: #11